### PR TITLE
Potential fix for code scanning alert no. 14: DOM text reinterpreted as HTML

### DIFF
--- a/403 Landing Page/script.js
+++ b/403 Landing Page/script.js
@@ -14,6 +14,15 @@ function map2(value, sourceMin, sourceMax, destMin, destMax, percent) {
   return map(value, sourceMin, sourceMax, destMin, destMax);
 }
 
+function escapeHtml(unsafe) {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 function fisheye(el) {
   let text = el.innerText.trim(),
     numberOfChars = text.length;
@@ -23,7 +32,7 @@ function fisheye(el) {
     text
       .split("")
       .map(c => {
-        return c === " " ? "&nbsp;" : c;
+        return c === " " ? "&nbsp;" : escapeHtml(c);
       })
       .join("</span><span>") +
     "</span>";


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/projects/security/code-scanning/14](https://github.com/venkateshpabbati/projects/security/code-scanning/14)

To fix the problem, we need to ensure that any text extracted from the DOM and reinserted as HTML is properly escaped to prevent XSS attacks. The best way to do this is to use a function that escapes HTML special characters before setting the `innerHTML` property.

1. Create a function to escape HTML special characters.
2. Use this function to escape each character in the `text` variable before joining them with `<span>` tags.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
